### PR TITLE
Allow SetProperty to work with WhenAny().ToProperty()

### DIFF
--- a/MvvmCross.ReactiveUI.Interop/MvxReactiveViewModel.cs
+++ b/MvvmCross.ReactiveUI.Interop/MvxReactiveViewModel.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel;
+using System.Runtime.CompilerServices;
 using MvvmCross.Core.ViewModels;
 using ReactiveUI;
 
@@ -48,6 +50,14 @@ namespace MvvmCross.ReactiveUI.Interop
         {
             add { this.reactiveObj.PropertyChanging += value; }
             remove { this.reactiveObj.PropertyChanging -= value; }
+        }
+
+        public new bool SetProperty<T>(ref T storage, T value, [CallerMemberName] string propertyName = null)
+        {
+            var original = storage;
+            IReactiveObjectExtensions.RaiseAndSetIfChanged(this, ref storage, value, propertyName);
+
+            return !EqualityComparer<T>.Default.Equals(original, value);
         }
     }
 }


### PR DESCRIPTION
MvvmCross convention is to use SetProperty for INPC.

Provide a way to do this that behaves with WhenAny().ToProperty().